### PR TITLE
get rid of globals

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,27 +1,23 @@
 'use strict';
 const crypto = require('crypto');
-let service;
-let token;
-let secret;
 
-let hmacAuthorize = {
-  sign: (method, path, contentType, body) => {
-    let ts = Math.floor(new Date().getTime() / 1000);
-    let message =
+let hmacAuthorize = (service, token, secret) => {
+  return {
+    sign: (method, path, contentType, body) => {
+      let ts = Math.floor(new Date().getTime() / 1000);
+      let message =
       `${method}\n${path}\n${(body ? contentType : '')}\n${ts}\n${(body ?
-      crypto.createHash('md5').update(body).digest('hex') : '')}`;
-    let signature =
+        crypto.createHash('md5').update(body).digest('hex') : '')}`;
+      let signature =
       crypto.createHmac('sha256', secret).update(message).digest('hex');
-    return `${service} ts=${ts} token=${token} signature=${signature}`;
-  }
+      return `${service} ts=${ts} token=${token} signature=${signature}`;
+    }
+  };
 };
 
 module.exports = function(config) {
   if (!config || !config.service || !config.token || !config.secret) {
     throw new Error('Missing service, token and/or secret.');
   }
-  service = config.service;
-  token = config.token;
-  secret = config.secret;
-  return hmacAuthorize;
+  return hmacAuthorize(config.service, config.token, config.secret);
 };


### PR DESCRIPTION
if you create multiple hmacAuthorize objects only the last one will work, as they store configuration in globals